### PR TITLE
Provide forwards compatibility with servicemanager v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,25 @@ matrix:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+    - php: 5.5
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.3"
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+    - php: 5.6
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.3"
     - php: 7
+    - php: 7
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.3"
     - php: hhvm 
+    - php: hhvm 
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.3"
   allow_failures:
-    - php: 7
+    - php: hhvm
 
 notifications:
   irc: "irc.freenode.org#zftalk.dev"
@@ -33,6 +45,8 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": ">=5.5"
+        "php": "^5.5 || ^7.0"
     },
     "suggest": {
         "zendframework/zend-servicemanager": "To support Zend\\Permissions\\Acl\\Assertion\\AssertionManager plugin manager usage"
@@ -23,7 +23,7 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.5-dev",
-            "dev-develop": "3.0-dev"
+            "dev-develop": "2.6-dev"
         }
     },
     "autoload-dev": {
@@ -34,7 +34,6 @@
     "require-dev": {
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0",
-        "zendframework/zend-di": "dev-develop as 2.7.0",
-        "zendframework/zend-servicemanager": "dev-develop as 2.7.0"
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0"
     }
 }

--- a/src/Assertion/AssertionManager.php
+++ b/src/Assertion/AssertionManager.php
@@ -47,7 +47,7 @@ class AssertionManager extends AbstractPluginManager
             ));
         }
     }
-  
+
     /**
      * Validate the plugin is of the expected type (v2).
      *

--- a/src/Assertion/AssertionManager.php
+++ b/src/Assertion/AssertionManager.php
@@ -8,11 +8,60 @@
  */
 namespace Zend\Permissions\Acl\Assertion;
 
+use Zend\Permissions\Acl\Exception\InvalidArgumentException;
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 
 class AssertionManager extends AbstractPluginManager
 {
+    /**
+     * zend-servicemanager v3 compatibility
+     * @var bool
+     */
+    protected $shareByDefault = true;
+
+    /**
+     * zend-servicemanager v2 compatibility
+     * @var bool
+     */
     protected $sharedByDefault = true;
 
     protected $instanceOf = AssertionInterface::class;
+
+    /**
+     * Validate the plugin is of the expected type (v3).
+     *
+     * Validates against `$instanceOf`.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validate($instance)
+    {
+        if (! $instance instanceof $this->instanceOf) {
+            throw new InvalidServiceException(sprintf(
+                '%s can only create instances of %s; %s is invalid',
+                get_class($this),
+                $this->instanceOf,
+                (is_object($instance) ? get_class($instance) : gettype($instance))
+            ));
+        }
+    }
+  
+    /**
+     * Validate the plugin is of the expected type (v2).
+     *
+     * Proxies to `validate()`.
+     *
+     * @param mixed $instance
+     * @throws InvalidArgumentException
+     */
+    public function validatePlugin($instance)
+    {
+        try {
+            $this->validate($instance);
+        } catch (InvalidServiceException $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
 }

--- a/test/Assertion/AssertionAggregateTest.php
+++ b/test/Assertion/AssertionAggregateTest.php
@@ -8,8 +8,8 @@
  */
 namespace ZendTest\Permissions\Acl\Assertion;
 
+use InvalidArgumentException;
 use Zend\Permissions\Acl\Assertion\AssertionAggregate;
-use Zend\Di\Exception\UndefinedReferenceException;
 
 class AssertionAggregateTest extends \PHPUnit_Framework_TestCase
 {
@@ -163,7 +163,7 @@ class AssertionAggregateTest extends \PHPUnit_Framework_TestCase
         $manager->expects($this->once())
             ->method('get')
             ->with('assertion')
-            ->will($this->throwException(new UndefinedReferenceException()));
+            ->will($this->throwException(new InvalidArgumentException()));
 
         $this->assertionAggregate->setAssertionManager($manager);
 

--- a/test/Assertion/AssertionManagerCompatibilityTest.php
+++ b/test/Assertion/AssertionManagerCompatibilityTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Permissions\Acl\Assertion;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Permissions\Acl\Assertion\AssertionInterface;
+use Zend\Permissions\Acl\Assertion\AssertionManager;
+use Zend\Permissions\Acl\Exception\InvalidArgumentException;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class AssertionManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new AssertionManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidArgumentException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return AssertionInterface::class;
+    }
+
+    public function testPluginAliasesResolve()
+    {
+        $this->markTestSkipped(
+            'No aliases yet defined; remove implementation if/when aliases are added to AssertionManager'
+        );
+    }
+}


### PR DESCRIPTION
This patch updates the develop branch to make it _forwards_ compatible with zend-servicemanager v3 (vs _only_ compatible), allowing a 2.6.0 version that supports both v2 and v3.

The following changes were made:
- Removal of the zend-di dev dependency; it was literally used only for throwing an exception from a mock object. The exception was safely replaced with an SPL exception.
- Updating of the zend-servicemanager dependency to `^2.7.5 || ^3.0`.
- Addition of the `AssertionManagerCompatibilityTest`, which leverages zend-servicemanager's `CommonPluginManagerTrait` to test both v2 and v3 compatibility of the `AssertionManager` implementation.
- Updating of the `AssertionManager` to work under both v2 and v3:
  - Addition of `$sharedByDefault` + `$shareByDefault`
  - Addition of both `validate()` and `validatePlugin()` methods
