### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - secure: "bZh4yvrLnuLt4oZQqHzyP58iMA6y7FlRYLhhbg+Lx1mezvd1zRGF7MNAuuCYmbmjFWOW9h2KtLdR3xRm9ZLHCrrC/s6N40gbBOLl7l2/e2gdmtTgnvI5+2fu8xy2ERxKwYSqaHYf6xJA8KJG0szj0aasue4+roCE+GUKoTzwvATPOFwoYmCkONRsvztGKsfTS4Fpy/Xyp2jFwBR7ye/5JzFFckjHgHBxaDSDxUgdIjp0Fevc9/lc3C5PmSO920ApfHvwFzZa0P0zLgNgg9VkI7/zTUw3Hay2T+jgWbCT0QchirJrnfgHMZrMsy3Qj3vHhj2dxGwH9q6EoVipfG9HtaTdNnfIyyzm7E8d/Wu8AXH6PE3TkovnLphPvusmRU9WT4itoSXagsN8o7YUs+gYx9IN2ehRnGZgy0pvFmYeDYVBYqnc2rnQ7+6bzKe2g50xvej3G9QPZwkvJeQE729vLFtZFQvqaLH8XRz+bMIkOXhd+ulHGIRpoJpVOSYnKca+40XzqbhGlUpidB95/PSU9hE+vpF266NiyqfVsABejC8T8VZmXnBhLJNkyk8VlKKws5iAEmPEpT3RX/zbAqMet7grPiO7NlRDVGN+MGrul14KvqXc8lE6AcxKheKgsA5eJiVJB/3ddO1Kc+Y5XGpgy+p9V7fOUQ+Mw+cPvAY1bb8="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.5
       env:


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.
