### PR TITLE
spelling fixes

### DIFF
--- a/test/AclTest.php
+++ b/test/AclTest.php
@@ -1294,7 +1294,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->_acl->isAllowed('guest', 'blogpost', 'read'));
         $this->assertFalse($this->_acl->isAllowed('guest', 'newsletter', 'read'));
 
-        // ensure allow null/all resoures works
+        // ensure allow null/all resources works
         $this->_acl->allow('guest', null, 'read');
         $this->assertTrue($this->_acl->isAllowed('guest', 'blogpost', 'read'));
         $this->assertTrue($this->_acl->isAllowed('guest', 'newsletter', 'read'));


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.