### PR TITLE
Performance Fix

### DIFF
--- a/src/Acl.php
+++ b/src/Acl.php
@@ -405,11 +405,7 @@ class Acl implements AclInterface
     public function removeResourceAll()
     {
         foreach ($this->resources as $resourceId => $resource) {
-            foreach ($this->rules['byResourceId'] as $resourceIdCurrent => $rules) {
-                if ($resourceId === $resourceIdCurrent) {
-                    unset($this->rules['byResourceId'][$resourceIdCurrent]);
-                }
-            }
+            unset($this->rules['byResourceId'][$resourceId]);
         }
 
         $this->resources = [];


### PR DESCRIPTION
unsetting a non-existing rule doesn't throw an error.
In our Project this change improves loading time from 55 sec to 0.5 sec
(14412 Resources, 11694 Rules)

see also
https://github.com/zendframework/zf1/pull/737