### PR TITLE
[wip] Hotfix/alternative fix for order of parents seems backwards

### DIFF
--- a/src/Acl.php
+++ b/src/Acl.php
@@ -913,20 +913,27 @@ class Acl implements AclInterface
             'stack'   => []
         ];
 
-        if (null !== ($result = $this->roleDFSVisitOnePrivilege($role, $resource, $privilege, $dfs))) {
-            return $result;
+        $returnResult = $this->roleDFSVisitOnePrivilege($role, $resource, $privilege, $dfs);
+        if ($returnResult === true) {
+            return $returnResult;
         }
 
-        // This comment is needed due to a strange php-cs-fixer bug
-        while (null !== ($role = array_pop($dfs['stack']))) {
+        while ($role = array_pop($dfs['stack'])) {
             if (! isset($dfs['visited'][$role->getRoleId()])) {
-                if (null !== ($result = $this->roleDFSVisitOnePrivilege($role, $resource, $privilege, $dfs))) {
-                    return $result;
+                $result = $this->roleDFSVisitOnePrivilege($role, $resource, $privilege, $dfs);
+                switch ($result) {
+                    case true:
+                        return true;
+                    case false:
+                        $returnResult = false;
+                        break;
+                    default;
+                        break;
                 }
             }
         }
 
-        return;
+        return $returnResult;
     }
 
     /**

--- a/test/AclTest.php
+++ b/test/AclTest.php
@@ -1147,6 +1147,15 @@ class AclTest extends TestCase
         }
     }
 
+    public function testAllRolesAreEvaluatedRegardlessOfOrderAddedToACL()
+    {
+        $acl = $this->loadUseCase1();
+
+        $user = new Role\GenericRole('hierarchy-admin');
+        $blogPost = new Resource\GenericResource('hierarchy-resource');
+
+        $this->assertTrue($acl->isAllowed($user, $blogPost, 'assert'));
+    }
 
     /**
      * @group ZF-1721

--- a/test/TestAsset/UseCase1/Acl.php
+++ b/test/TestAsset/UseCase1/Acl.php
@@ -27,5 +27,13 @@ class Acl extends \Zend\Permissions\Acl\Acl
         $this->allow('contributor', 'blogPost', 'contribute');
         $this->allow('contributor', 'blogPost', 'modify', $this->customAssertion);
         $this->allow('publisher', 'blogPost', 'publish');
+
+        // for AclTest::testAllRolesAreEvaluatedRegardlessOfOrderAddedToACL
+        $this->addRole(new \Zend\Permissions\Acl\Role\GenericRole('hierarchy-guest'));
+        $this->addRole(new \Zend\Permissions\Acl\Role\GenericRole('hierarchy-user'), 'hierarchy-guest');
+        $this->addRole(new \Zend\Permissions\Acl\Role\GenericRole('hierarchy-admin'), ['hierarchy-user', 'hierarchy-guest']);
+        $this->addResource(new \Zend\Permissions\Acl\Resource\GenericResource('hierarchy-resource'));
+        $this->allow('hierarchy-user', 'hierarchy-resource', 'assert');
+        $this->deny('hierarchy-guest', 'hierarchy-resource', 'assert');
     }
 }


### PR DESCRIPTION
An alternative fix instead of https://github.com/zendframework/zend-permissions-acl/pull/31